### PR TITLE
Fix register name identification via rest api

### DIFF
--- a/src/modbussim/modbussim.py
+++ b/src/modbussim/modbussim.py
@@ -132,7 +132,7 @@ class ModbusSim(Simulator):
                 register_name + '_register_type': register_type
             }})
             if register_count > 0:
-                slave.add_block(register_name + '_registers', register_type, start_address, register_count)
+                slave.add_block(register_name, register_type, start_address, register_count)
 
         self.slaves.update({slave_id: registers_dict})
 
@@ -171,7 +171,7 @@ class ModbusSim(Simulator):
             registers = []
 
             if register_count > 0:
-                registers = slave.get_values(register_name + '_registers', start_address, register_count)
+                registers = slave.get_values(register_name, start_address, register_count)
 
             if not toReturn.endswith('['):
                 toReturn += ','
@@ -211,9 +211,9 @@ class ModbusSim(Simulator):
                 slave.remove_block(register_name)
         
         if register_count > 0:
-            slave.add_block(register_name + '_registers',
+            slave.add_block(register_name,
                             register_type, start_address, register_count)
-            slave.set_values(register_name + '_registers', start_address, register_data)
+            slave.set_values(register_name, start_address, register_data)
 
         registers_dict.update({register_name : {
                 register_name + '_register_count': register_count,

--- a/src/server.py
+++ b/src/server.py
@@ -471,7 +471,6 @@ def slave_read(slave_id, block, address):
     return str(value[0])
 
 
-@app.route('/slave/<int:slave_id>/<int:address>', methods=['POST'])
 @app.route('/modbus/slave/<int:slave_id>/<string:block>/<int:address>', methods=['POST'])
 def slave_write(slave_id, block, address):
     """
@@ -649,9 +648,9 @@ def main():
 
 if __name__ == '__main__':
     signal.signal(signal.SIGABRT, signal_handler)
-    signal.signal(signal.SIGHUP, signal_handler)
+    #signal.signal(signal.SIGHUP, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGQUIT, signal_handler)
+    #signal.signal(signal.SIGQUIT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     main()
     app.run(host=config.get('server','host'), port=config.getint('server','port'),


### PR DESCRIPTION
change register name identifier (removing postfix '_registers') to fix register name identification via REST api
remove unsupported route (block is required)
comment signals not supported under WSL